### PR TITLE
chore: update future work

### DIFF
--- a/src/content/docs/case-study/future-work.mdx
+++ b/src/content/docs/case-study/future-work.mdx
@@ -4,17 +4,16 @@ sidebar:
   order: 7
 ---
 
-## Supporting other models
+## Supporting Other Models
 
 Kubrick currently works with the Twelve Labs embedding model, but future updates
-could extend compatibility to other commercial video multi-embedding providers
-like Google Vertex AI or new services as they emerge. We also see potential in
-exploring open-source models such as InternVideo2, which would make on-premises
-and cost-effective deployments possible. This flexibility could give teams the
-choice between high-accuracy, fully managed APIs and privacy-focused,
-self-hosted solutions.
+could add compatibility for other commercial video multimodal embedding models
+as they emerge. We also see potential in exploring open-source models like
+LanguageBind, which would make on-premises and cost-effective deployments
+possible. This flexibility could give teams the choice between high-accuracy,
+fully managed APIs and privacy-focused, self-hosted solutions.
 
-## Query rewriting for improved search
+## Query Rewriting for Improved Search
 
 Through our work with semantic video search, we’ve found that more descriptive
 queries tend to produce better results. In the future, Kubrick could include an
@@ -24,15 +23,15 @@ visible in the background”). This would make searching more intuitive for all
 users and improve accuracy without requiring them to carefully craft their
 queries.
 
-## Re-ranking search results
+## Re-ranking Search Results
 
 Another possible enhancement is adding a re-ranking step to further improve
 search accuracy. After the initial search identifies the top matches, a large
 multimodal model could review and re-score the best 50 segments. This would help
 surface the most relevant clips first, particularly for complex or ambiguous
-searches.
+searches, at the cost of adding latency.
 
-## VLM integration for video chat
+## VLM Integration
 
 Looking ahead, Kubrick could support conversational video exploration by
 integrating Video-Language Models (VLMs) such as Twelve Labs Pegasus, Google
@@ -41,7 +40,7 @@ could answer natural-language questions like, “Summarize the events in the las
 two minutes,” providing context-aware responses that combine visual, scene, and
 audio understanding.
 
-## Authentication for the API
+## API Authentication
 
 Currently, the Kubrick API is open to simplify experimentation and allow teams
 to implement their own authentication methods. In the future, we could offer
@@ -49,7 +48,7 @@ built-in security options such as API keys, OAuth2, or JWT-based authentication.
 This would give teams an easier way to secure Kubrick without extra
 infrastructure.
 
-## Adding Cache Support for Ingestion Embeddings
+## Cache Support for Ingestion Embeddings
 
 Currently, only embedding requests for search queries utilise the cache layer.
 The ingestion pipeline generates a new embedding on every valid S3 Create event.


### PR DESCRIPTION
- Section Header capitalisation
- remove internVideo2 reference, since we explain why we don't use it currently in prev section. Replaced with LanguageBind, which could be a viable option